### PR TITLE
button disabled after first upload.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <body>
   <div id="header">
     <h1>Parallel Plots</h1>
-    <input type="file" onchange="loadFile()" />
+    <input id="upload-file" type="file" onchange="loadFile()" />
 
   <script>
     var reader = new FileReader();  

--- a/parallel.js
+++ b/parallel.js
@@ -73,6 +73,7 @@ function make_viz() {
     };
     return d;
   });
+  document.getElementById("upload-file").disabled = true;
 
   // Extract the list of numerical dimensions and create a scale for each.
   xscale.domain(dimensions = d3.keys(data[0]).filter(function(k) {


### PR DESCRIPTION
disables uploading a second time, preventing application failure. 

ideally we could re-upload a csv, but for now, this will do. 